### PR TITLE
Properly manage Facebook login as a side effect

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6723,6 +6723,11 @@
 				"symbol-observable": "1.0.4"
 			}
 		},
+		"redux-observable": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-0.17.0.tgz",
+			"integrity": "sha512-nVRl9KxdDNLKQRBkQK/svQIYDgTTDJbn3DEG6JB/DauZQs9bYl6R7b6ospXAS1zs6THarWHd3BhTTnGXFybVdA=="
+		},
 		"redux-persist": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-5.4.0.tgz",
@@ -6973,7 +6978,6 @@
 			"version": "5.5.2",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
 			"integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
-			"dev": true,
 			"requires": {
 				"symbol-observable": "1.0.4"
 			}

--- a/app/package.json
+++ b/app/package.json
@@ -21,9 +21,11 @@
     "react-native-navigation": "^1.1.262",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
+    "redux-observable": "^0.17.0",
     "redux-persist": "^5.4.0",
     "redux-reset": "^0.3.0",
-    "reduxsauce": "^0.7.0"
+    "reduxsauce": "^0.7.0",
+    "rxjs": "^5.5.2"
   },
   "devDependencies": {
     "babel-jest": "21.2.0",

--- a/app/src/Api/Facebook.js
+++ b/app/src/Api/Facebook.js
@@ -1,23 +1,19 @@
 import { FBLoginManager } from 'react-native-facebook-login'
-import { goHome } from 'app/Api/Navigation'
 
-export const login = () => {
-  FBLoginManager.setLoginBehavior(FBLoginManager.LoginBehaviors.Web) // defaults to Native
+export const login = () =>
+  new Promise((resolve, reject) => {
+    FBLoginManager.setLoginBehavior(FBLoginManager.LoginBehaviors.Web) // defaults to Native
 
-  FBLoginManager.loginWithPermissions(['email'], (error, data) => {
-    if (!error && data && data.credentials) {
-      // all good, we can proceed
-      // console.tron.log(data)
-      goHome()
-    } else if (
-      error === 'Cancel' ||
-      (typeof error === 'object' && error.type === 'cancel')
-    ) {
-      // cancelled by the user, we likely do nothing and go back to the login screen
-      // console.tron.log('Cancel!', error)
-    } else {
-      // in this case there was another sort of error, we may want to show a message
-      // console.tron.log('UPS!!!', error, data)
-    }
+    FBLoginManager.loginWithPermissions(['email'], (error, data) => {
+      if (!error && data && data.credentials) {
+        resolve(data.credentials)
+      } else {
+        const cause =
+          error === 'Cancel' ||
+          (typeof error === 'object' && error.type === 'cancel')
+            ? 'Cancel'
+            : error
+        reject(cause)
+      }
+    })
   })
-}

--- a/app/src/Redux/User.js
+++ b/app/src/Redux/User.js
@@ -1,0 +1,41 @@
+import { login } from 'app/Api/Facebook'
+import { goHome } from 'app/Api/Navigation'
+import { createReducer, createActions } from 'reduxsauce'
+import { Observable } from 'rxjs'
+import 'rxjs/add/operator/mergeMap'
+import 'rxjs/add/operator/map'
+import 'rxjs/add/operator/do'
+
+const INITIAL_STATE = {
+  token: null
+}
+
+const { Types, Creators } = createActions({
+  startLogin: null,
+  userLogged: ['token'],
+  loginFailed: ['error'],
+  logout: null
+})
+
+export const userLogged = (state, { token }) => ({ ...state, token })
+
+export const logout = state => INITIAL_STATE
+
+export default Creators
+
+export const UserTypes = Types
+
+export const reducer = createReducer(INITIAL_STATE, {
+  [Types.USER_LOGGED]: userLogged,
+  [Types.LOGOUT]: logout
+})
+
+export const epic = (action$, store) =>
+  action$
+    .ofType(Types.START_LOGIN)
+    .flatMap(() => login())
+    .do(() => {
+      goHome()
+    })
+    .map(({ token }) => Creators.userLogged(token))
+    .catch(error => Observable.of(Creators.loginFailed(error)))

--- a/app/src/Redux/index.js
+++ b/app/src/Redux/index.js
@@ -1,9 +1,11 @@
 import Config from 'app/Config/DebugSettings'
 import { createStore, applyMiddleware, compose } from 'redux'
 import { persistStore, persistCombineReducers } from 'redux-persist'
+import { combineEpics, createEpicMiddleware } from 'redux-observable'
 import storage from 'redux-persist/es/storage'
 import reduxReset from 'redux-reset'
 import { reducer as report } from './Report'
+import { reducer as user, epic as userEpic } from './User'
 
 const config = {
   key: 'root',
@@ -13,8 +15,13 @@ const config = {
 const middleware = []
 
 const rootReducer = persistCombineReducers(config, {
+  user,
   report
 })
+
+const rootEpic = combineEpics(userEpic)
+
+middleware.push(createEpicMiddleware(rootEpic))
 
 const actualCreateStore = Config.useReactotron
   ? console.tron.createStore

--- a/app/src/Screens/SignIn/index.js
+++ b/app/src/Screens/SignIn/index.js
@@ -1,14 +1,16 @@
 import React, { Component } from 'react'
 import { Text, View, Image } from 'react-native'
-import { goHome } from 'app/Api/Navigation'
-import { login } from 'app/Api/Facebook'
+import UserActions from 'app/Redux/User'
 import DefaultLayout from 'app/Layouts/Default'
 import Button from 'app/Components/Button'
-import styles from './style'
+import { connect } from 'react-redux'
+
 import I18n from 'app/Locales'
 import images from 'app/Theme/images'
 
-export default class Help extends Component {
+import styles from './style'
+
+class SignIn extends Component {
   componentWillMount() {
     this.props.navigator.setStyle({
       navBarHidden: true
@@ -35,7 +37,7 @@ export default class Help extends Component {
           <Button
             buttonStyle={styles.button}
             textStyle={styles.buttonText}
-            onPress={login}
+            onPress={this.props.startLogin}
             text={I18n.t('screens.signIn.button')}
           />
         </View>
@@ -43,3 +45,9 @@ export default class Help extends Component {
     )
   }
 }
+
+const mapStateToProps = state => ({})
+
+const mapDispatchToProps = UserActions
+
+export default connect(mapStateToProps, mapDispatchToProps)(SignIn)


### PR DESCRIPTION
using redux-observable
known issue: (seems like this is prior to this commit). FBLoginManager
seems to “cache” the result of the login request, which may cause funky
results on retries